### PR TITLE
Add Linux-on-ARM runner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-26, macos-15, macos-14]
+        os: [macos-26, macos-15, macos-14, ubuntu-24.04, ubuntu-24.04-arm]
     runs-on: ${{ matrix.os }}
     permissions:
       actions: read
@@ -18,6 +18,11 @@ jobs:
       contents: read
       pull-requests: read
     steps:
+      - name: Install Homebrew on Linux/ARM
+        if: matrix.os == 'ubuntu-24.04-arm'
+        run: |
+          NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@main


### PR DESCRIPTION
Add `ubuntu-24.04-arm` to the strategy matrix for tests and bottling.

Homebrew now supports Linux on ARM at Tier 1.
As `ubuntu-24.04-arm` doesn't yet come with Homebrew installed, a step is added to install Homebrew first on this runner.